### PR TITLE
Update ftst_rengrps.F

### DIFF
--- a/nf_test/ftst_rengrps.F
+++ b/nf_test/ftst_rengrps.F
@@ -11,7 +11,7 @@ C      use typeSizes
 C      use netcdf
 C      use netcdf4_f03
       implicit none
-     include "netcdf.inc"
+      include "netcdf.inc"
       
 C This is the name of the data file we will create.
       character (len = *), parameter :: FILE_NAME = "ftst_rengrps.nc"


### PR DESCRIPTION
Indented the `include netcdf.inc` command one additional space.  The misindentation was causing `ifort` to throw an error; gfortran seems more forgiving.